### PR TITLE
Improvments to changeset tags

### DIFF
--- a/osm_bot_abstraction_layer/generic_bot_retagging.py
+++ b/osm_bot_abstraction_layer/generic_bot_retagging.py
@@ -35,7 +35,7 @@ def splitter_generator(edit_element):
                 urls_of_handled_elements.append(element.get_link())
     return splitter_generated # returns a callback function
 
-def build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source=None):
+def build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source=None, other_tags_dict = {}):
     if len(changeset_comment) < 4:
         raise Exception("changeset_comment is unreasonably short: " + changeset_comment)
     automatic_status = osm_bot_abstraction_layer.manually_reviewed_description()
@@ -44,7 +44,7 @@ def build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wi
     comment = changeset_comment
     api = osm_bot_abstraction_layer.get_correct_api(automatic_status, discussion_url, osm_wiki_documentation_page)
     affected_objects_description = ""
-    builder = osm_bot_abstraction_layer.ChangesetBuilder(affected_objects_description, comment, automatic_status, discussion_url, osm_wiki_documentation_page, source)
+    builder = osm_bot_abstraction_layer.ChangesetBuilder(affected_objects_description, comment, automatic_status, discussion_url, osm_wiki_documentation_page, source, other_tags_dict)
     builder.create_changeset(api)
     return api
 
@@ -105,7 +105,7 @@ def note_creation_block_reason(lat, lon):
             return "Within Moscow bbox, skipping for now - see https://www.openstreetmap.org/note/3866541"
     return None
 
-def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None):
+def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None, other_tags_dict = {}):
     changeset = None
     for element in package.list:
 
@@ -122,7 +122,7 @@ def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, 
                 retry_remaining_attempts -= 1
                 try:
                     if changeset == None:
-                        changeset = build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source)
+                        changeset = build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source, other_tags_dict)
                     osm_bot_abstraction_layer.update_element(changeset, element.element.tag, data)
                     break # completed succesfully, no need to repeat
                 except osmapi.ApiError as e:
@@ -207,18 +207,18 @@ def show_planned_edits(packages, edit_element_function):
                     print("#* added_:", key,"=", after[key])
             print()
 
-def run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None):
+def run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None, other_tags_dict = {}):
     for package in packages:
         for element in package.list:
             print(element.get_link())
-        process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source)
+        process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source, other_tags_dict)
         print()
         print()
 
 def run_simple_retagging_task(max_count_of_elements_in_one_changeset, objects_to_consider_query,
     cache_folder_filepath, is_in_manual_mode,
     changeset_comment, discussion_url, osm_wiki_documentation_page,
-    edit_element_function, skip_on_nearby_notes=False, source=None):
+    edit_element_function, skip_on_nearby_notes=False, source=None, other_tags_dict = {}):
     hashed = hashlib.sha256(objects_to_consider_query.encode('utf-8')).hexdigest()
     if cache_folder_filepath[-1] == "/":
         raise Exception("provide folder path without trailing /")
@@ -250,7 +250,7 @@ def run_simple_retagging_task(max_count_of_elements_in_one_changeset, objects_to
             print(str(len(list_of_elements)) + " objects split into " + str(len(packages)) + " edits. Continue? [y/n]")
             if human_verification_mode.is_human_confirming_without_browser_check() == False:
                 return
-    run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source)
+    run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source, other_tags_dict)
 
 def check_value_list_before_bot_edit_proposal(key, value_list):
     """

--- a/osm_bot_abstraction_layer/generic_bot_retagging.py
+++ b/osm_bot_abstraction_layer/generic_bot_retagging.py
@@ -35,14 +35,13 @@ def splitter_generator(edit_element):
                 urls_of_handled_elements.append(element.get_link())
     return splitter_generated # returns a callback function
 
-def build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page):
+def build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source=None):
     if len(changeset_comment) < 4:
         raise Exception("changeset_comment is unreasonably short: " + changeset_comment)
     automatic_status = osm_bot_abstraction_layer.manually_reviewed_description()
     if is_in_manual_mode == False:
         automatic_status = osm_bot_abstraction_layer.fully_automated_description()
     comment = changeset_comment
-    source = None
     api = osm_bot_abstraction_layer.get_correct_api(automatic_status, discussion_url, osm_wiki_documentation_page)
     affected_objects_description = ""
     builder = osm_bot_abstraction_layer.ChangesetBuilder(affected_objects_description, comment, automatic_status, discussion_url, osm_wiki_documentation_page, source)
@@ -106,7 +105,7 @@ def note_creation_block_reason(lat, lon):
             return "Within Moscow bbox, skipping for now - see https://www.openstreetmap.org/note/3866541"
     return None
 
-def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes):
+def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None):
     changeset = None
     for element in package.list:
 
@@ -123,7 +122,7 @@ def process_osm_elements_package(package, is_in_manual_mode, changeset_comment, 
                 retry_remaining_attempts -= 1
                 try:
                     if changeset == None:
-                        changeset = build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page)
+                        changeset = build_changeset(is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, source)
                     osm_bot_abstraction_layer.update_element(changeset, element.element.tag, data)
                     break # completed succesfully, no need to repeat
                 except osmapi.ApiError as e:
@@ -208,18 +207,18 @@ def show_planned_edits(packages, edit_element_function):
                     print("#* added_:", key,"=", after[key])
             print()
 
-def run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes):
+def run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source=None):
     for package in packages:
         for element in package.list:
             print(element.get_link())
-        process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes)
+        process_osm_elements_package(package, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source)
         print()
         print()
 
 def run_simple_retagging_task(max_count_of_elements_in_one_changeset, objects_to_consider_query,
     cache_folder_filepath, is_in_manual_mode,
     changeset_comment, discussion_url, osm_wiki_documentation_page,
-    edit_element_function, skip_on_nearby_notes=False):
+    edit_element_function, skip_on_nearby_notes=False, source=None):
     hashed = hashlib.sha256(objects_to_consider_query.encode('utf-8')).hexdigest()
     if cache_folder_filepath[-1] == "/":
         raise Exception("provide folder path without trailing /")
@@ -251,7 +250,7 @@ def run_simple_retagging_task(max_count_of_elements_in_one_changeset, objects_to
             print(str(len(list_of_elements)) + " objects split into " + str(len(packages)) + " edits. Continue? [y/n]")
             if human_verification_mode.is_human_confirming_without_browser_check() == False:
                 return
-    run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes)
+    run_actual_edits(packages, is_in_manual_mode, changeset_comment, discussion_url, osm_wiki_documentation_page, edit_element_function, skip_on_nearby_notes, source)
 
 def check_value_list_before_bot_edit_proposal(key, value_list):
     """

--- a/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
+++ b/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
@@ -58,6 +58,8 @@ class ChangesetBuilder:
         # allow specifing other changeset tags and overwriting hardcoded ones
         for other_tags_key, other_tags_value in other_tags_dict:
             self.changeset_description[other_tags_key] = other_tags_value
+        changeset_description_cleanup = {key: val for key, val in self.changeset_description() if val}
+        self.changeset_description = changeset_description_cleanup
 
     def create_changeset(self, api):
         print("opening changeset", json.dumps(self.changeset_description, sort_keys=True, indent=4))

--- a/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
+++ b/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
@@ -42,7 +42,7 @@ class ChangesetBuilder:
     def __init__(self, affected_objects_description, comment, automatic_status, discussion_url, osm_wiki_documentation_page, source, other_tags_dict = {}):
         if automatic_status not in [fully_automated_description(), manually_reviewed_description()]:
             raise "automatic status must match either description returned by fully_automated_description() or manually_reviewed_description() from osm_abstraction_layer"
-        self.changeset_description = other_tags_dict
+        self.changeset_description = {}
         self.changeset_description['mechanical'] = automatic_status
         if automatic_status == fully_automated_description():
             if osm_wiki_documentation_page == None or discussion_url == None:
@@ -55,6 +55,9 @@ class ChangesetBuilder:
         if source != None:
             self.changeset_description["source"] = source
         self.changeset_description['comment'] = output_full_comment_get_comment_within_limit(affected_objects_description, comment)
+        # allow specifing other changeset tags and overwriting hardcoded ones
+        for other_tags_key, other_tags_value in other_tags_dict:
+            self.changeset_description[other_tags_key] = other_tags_value
 
     def create_changeset(self, api):
         print("opening changeset", json.dumps(self.changeset_description, sort_keys=True, indent=4))

--- a/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
+++ b/osm_bot_abstraction_layer/osm_bot_abstraction_layer.py
@@ -56,9 +56,9 @@ class ChangesetBuilder:
             self.changeset_description["source"] = source
         self.changeset_description['comment'] = output_full_comment_get_comment_within_limit(affected_objects_description, comment)
         # allow specifing other changeset tags and overwriting hardcoded ones
-        for other_tags_key, other_tags_value in other_tags_dict:
+        for other_tags_key, other_tags_value in other_tags_dict.items():
             self.changeset_description[other_tags_key] = other_tags_value
-        changeset_description_cleanup = {key: val for key, val in self.changeset_description() if val}
+        changeset_description_cleanup = {key: val for key, val in self.changeset_description.items() if val}
         self.changeset_description = changeset_description_cleanup
 
     def create_changeset(self, api):


### PR DESCRIPTION
This PR improves the handling of changeset description tags

- pass source through (optionaly) so it can be used e.g. from simple_retagging_task
- pass other_changeset_tags through (same as source)
- hard coded changeset description can be overwritten by providing the key empty in other_changeset_tags

Not sure I've updated the pass through at all relevant places, but for simple_retagging it should work.

#15 #2